### PR TITLE
Handle zero-velocity note releases

### DIFF
--- a/RetroCade_Sketch/RetroCade_Sketch.ino
+++ b/RetroCade_Sketch/RetroCade_Sketch.ino
@@ -266,6 +266,8 @@ void HandlePitchBend(byte channel, int bend) {
 }
 
 void HandleNoteOn(byte channel, byte pitch, byte velocity) {
+  if ( velocity == 0 )
+    return HandleNoteOff(channel, pitch, velocity);
   #ifdef DEBUG
     Serial.print("Note Received: ");
     Serial.println(pitch);


### PR DESCRIPTION
Many MIDI keyboards, controllers, and software don't send actual NoteOff data, instead sending NoteOn with velocity 0 to indicate the end of the note.   MIDI 1.0+ specifies that this should be interpreted the same as a NoteOff, just without a specific release velocity.
